### PR TITLE
Remove special case for pointer struct member

### DIFF
--- a/xndtools/structinfo_generator.py
+++ b/xndtools/structinfo_generator.py
@@ -177,13 +177,8 @@ static PyObject *pyc_{fname}(PyObject *self, PyObject *args) {{
             
             fname = f'get_{typename}_{membernames}'
 
-            if typespec.endswith('*'):
-                lines.append(f'extern /* `{typespec}` */ void * {fname}(void* ptr){{ return (void*)((({typename}*)ptr)->{memberattrs}); }}')
-                fdoc = f'"{fname}(< capsule({typename}) >) -> < capsule( {typename}->{memberattrs} ) >"'
-                
-            else: # scalar
-                lines.append(f'extern /* pointer to `{typespec}` */ void * {fname}(void* ptr){{ return &((({typename}*)ptr)->{memberattrs}); }}')
-                fdoc = f'"{fname}(< capsule({typename}) >) -> < capsule( &{typename}->{memberattrs} ) >"'
+            lines.append(f'extern /* pointer to `{typespec}` */ void * {fname}(void* ptr){{ return &((({typename}*)ptr)->{memberattrs}); }}')
+            fdoc = f'"{fname}(< capsule({typename}) >) -> < capsule( &{typename}->{memberattrs} ) >"'
 
             pyc_func = f'''\
 static PyObject *pyc_{fname}(PyObject *self, PyObject *args) {{


### PR DESCRIPTION
changes the structinfo generator to always return a pointer to the
struct member, instead of returning the value when the member is already
a pointer. This makes the logic more uniform in numba-xnd for generating
struct getters and setters that use these generated functions.

I am already using this version of the generator in numba-xnd.