### PR TITLE
Adding preprocessor directive functionality to xndtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
 python:
   - "3.6"
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
 install:
+  - sudo apt-get install -qq gcc-6
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
@@ -28,5 +33,3 @@ before_script:
 
 script:
   - pytest -v xndtools/
-
-

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ def kernel_generator_test_modules():
             extra_link_args = extra_link_args,
             runtime_library_dirs = runtime_library_dirs
         )
-        
+
         extensions.append(ext)
-        
+
     return extensions
 
 data_files = (
@@ -130,7 +130,7 @@ def setup_package():
     sys.path.insert(0, src_path)
 
     ext_modules = kernel_generator_test_modules()
-    
+
     metadata = dict(
        name='xndtools',
         description=DESCRIPTION,
@@ -157,7 +157,7 @@ def setup_package():
             "gumath == v0.2.0.dev3"
         ],
         include_package_data=True,
-        packages=['xndtools', 'xndtools.kernel_generator'],
+        packages=['xndtools', 'xndtools.kernel_generator', 'xndtools.c_utils'],
         # package_data={'xndtools': data_files},
         scripts=['scripts/xnd_tools', 'scripts/structinfo_generator'],
         cmdclass={'build_py': my_build_py},
@@ -165,7 +165,7 @@ def setup_package():
         setup_requires=['pytest-runner'],
         tests_require=['pytest'],
     )
-    
+
     try:
         setup(**metadata)
     finally:

--- a/update_xnd.sh
+++ b/update_xnd.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -ex
+
 CWD=$(pwd)
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -9,11 +11,11 @@ if [[ -z "${TRAVIS}" ]]; then
     if ! [ -d $DIR/ndtypes ]; then
 	git clone git@github.com:plures/ndtypes.git
     fi
-    
+
     if ! [ -d $DIR/xnd ]; then
 	git clone git@github.com:plures/xnd.git
     fi
-    
+
     if ! [ -d $DIR/gumath ]; then
 	git clone git@github.com:plures/gumath.git
     fi

--- a/xndtools/c_utils/__init__.py
+++ b/xndtools/c_utils/__init__.py
@@ -1,0 +1,2 @@
+from .preprocessor import preprocess
+from .parser import get_enums, get_c_blocks, get_structs

--- a/xndtools/c_utils/__init__.py
+++ b/xndtools/c_utils/__init__.py
@@ -1,2 +1,2 @@
-from .preprocessor import preprocess
+from .preprocessor import preprocess, find_include
 from .parser import get_enums, get_c_blocks, get_structs

--- a/xndtools/c_utils/__main__.py
+++ b/xndtools/c_utils/__main__.py
@@ -6,6 +6,7 @@ from . import get_c_blocks, get_enums, get_structs
 
 def test():
     fn = sys.argv[1]
+    print('Processing:', sys.argv[1])
     r, blocks = get_c_blocks(open(fn).read())
 
     r = get_enums(open(fn).read())

--- a/xndtools/c_utils/__main__.py
+++ b/xndtools/c_utils/__main__.py
@@ -1,0 +1,20 @@
+from pprint import pprint
+import sys
+
+from . import get_c_blocks, get_enums, get_structs
+
+
+def test():
+    fn = sys.argv[1]
+    r, blocks = get_c_blocks(open(fn).read())
+
+    r = get_enums(open(fn).read())
+    print('ENUMS:')
+    print(r)
+
+    r = get_structs(open(fn).read())
+    print('STRUCTS:')
+    pprint(r)
+
+if __name__ == '__main__':
+    test()

--- a/xndtools/c_utils/preprocessor.py
+++ b/xndtools/c_utils/preprocessor.py
@@ -1,0 +1,84 @@
+import os
+import re
+import subprocess
+import shutil
+
+
+def preprocess(source, include_dirs=(), skip_includes=()):
+    """ Preprocess c source files naively or with compiler
+
+    """
+    source = _remove_comments(source)
+    source = _resolve_includes(source, include_dirs=include_dirs, skip_includes=skip_includes)
+    source = _resolve_macros(source, identifiers={})
+    return source
+
+
+def _remove_comments(source):
+    """ Return source without comments.
+    """
+    comment_re = r'(/[*].*?[*]/)|(//[^\n]*)'
+    return re.sub(comment_re,'', source, flags=re.MULTILINE | re.DOTALL)
+
+
+def _resolve_includes(source, include_dirs=(), skip_includes=()):
+    """ Return source with includes resolved.
+
+    Unresolved includes are ignored.
+
+    Parameters
+    ----------
+    source : str
+      Specify C source code.
+    include_dirs : list
+      Specify a list include directories.
+
+    Returns
+    -------
+    source : str
+      Source with resolved includes.
+
+    """
+    include_re = r'#include\s*[<"]([^"<>]+)[>"]'
+    def include_repl(m):
+        include_file = _find_include(m.group(1), include_dirs)
+        if not os.path.isfile(include_file) or include_file in skip_includes:
+            #print('skip', include_file)
+            return source[slice(*m.span())]
+        print('including', include_file)
+        f = open(include_file)
+        include_content = remove_comments(f.read())
+        f.close()
+        skip_includes.append(include_file)
+        return resolve_includes(include_content, include_dirs = include_dirs, skip_includes = skip_includes)
+    return re.sub(include_re, include_repl, source, re.MULTILINE)
+
+
+def _find_include(include, include_dirs):
+    """ Return path to include file in given include directories.
+    """
+    if os.path.isfile(include):
+        return include
+    for d in include_dirs:
+        path = os.path.join(d, include)
+        if os.path.isfile(path):
+            return path
+    return include
+
+
+def _resolve_macros(source, identifiers=set()):
+    """ Return source with macros evaluated
+
+    Only basic handling for now of several macros
+      - #ifdef, #else, #endif
+    """
+    ifdef_re = r'#ifdef (\w+)(.*?)(?:#else(.*?))?#endif'
+
+    def macro_repl(m):
+        identifier, true_stmt, false_stmt = m.groups()
+        if identifier in identifiers:
+            return true_stmt
+        else:
+            return false_stmt
+
+    return re.sub(ifdef_re, macro_repl, source, flags=re.MULTILINE | re.DOTALL)

--- a/xndtools/c_utils/tests/test_parser.py
+++ b/xndtools/c_utils/tests/test_parser.py
@@ -1,0 +1,12 @@
+from xndtools.c_utils import parser
+
+def test_get_c_blocks():
+    source = '''
+struct foobar {
+  int a;
+} foobar_t
+'''
+    assert parser.get_c_blocks(source) == (
+        '\nstruct foobar @@@1@@@ foobar_t\n',
+        {'@@@1@@@': '{\n  int a;\n}'}
+    )

--- a/xndtools/c_utils/tests/test_preprocessor.py
+++ b/xndtools/c_utils/tests/test_preprocessor.py
@@ -1,0 +1,36 @@
+from xndtools.c_utils import preprocessor
+
+def test_remove_comments():
+    source = '''
+// Hello World
+int a = 1;
+/* this is a comment
+ * asdfasdfasdf
+ */
+int b;// asdf
+'''
+    assert preprocessor._remove_comments(source) == '''
+
+int a = 1;
+
+int b;
+'''
+
+def test_resolve_macros():
+    source = '''
+#ifdef ASDF
+int a = 1;
+#else
+int b = 2;
+#endif
+'''
+    assert preprocessor._resolve_macros(source) == '''
+
+int b = 2;
+
+'''
+    assert preprocessor._resolve_macros(source, {'ASDF'}) == '''
+
+int a = 1;
+
+'''

--- a/xndtools/c_utils/tests/test_preprocessor.py
+++ b/xndtools/c_utils/tests/test_preprocessor.py
@@ -34,3 +34,10 @@ int b = 2;
 int a = 1;
 
 '''
+
+def test_preprocessor():
+    preprocessor.preprocess('''
+#include <stdio.h>
+
+int a = 1;
+    ''')


### PR DESCRIPTION
These changes were necessary to get xndtools to properly handle c directives that were introduced in `ndtypes.h`. See issue https://github.com/Quansight-Labs/numba-xnd/issues/18

The preprocessor can optionally use a compiler preprocessor such as `gcc` with `use_compiler=True`.

The c directive functionality is very limited and can only handle the following. However, it is flexible enough to add future features if necessary.

```c
#ifdef identifier
   ...
#else 
  ...
#endif
```

I have refactored the `c_utils.py` logic in order to separate the preprocessing from the parsing. Additionally several tests were added to ensure that each preprocessor function does the appropriate actions.

